### PR TITLE
pytest: Change pytest tests function signature - Option 2

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,8 +10,15 @@ import os
 
 import pytest
 
-from ethereum_test_tools import JSONEncoder, fill_test
 from ethereum_test_forks import ArrowGlacier
+from ethereum_test_tools import (
+    BlockchainTest,
+    BlockchainTestFiller,
+    JSONEncoder,
+    StateTest,
+    StateTestFiller,
+    fill_test,
+)
 from evm_block_builder import EvmBlockBuilder
 from evm_transition_tool import EvmTransitionTool
 
@@ -127,11 +134,10 @@ def reference_spec():
 
 
 @pytest.fixture(scope="function")
-def state_test():
+def state_test() -> StateTestFiller:
     """
-    This fixture is used to store a StateTest object from within a test
-    function so that it can be filled post test function execution in
-    the pytest_runtest_call() hook.
+    Fixture used to instantiate an auto-fillable StateTest object from within
+    a test function.
 
     Every test that defines a StateTest filler must explicitly specify this
     fixture in its function arguments and set the StateTestWrapper's spec
@@ -139,25 +145,29 @@ def state_test():
 
     Implementation detail: It must be scoped on test function level to avoid
     leakage between tests.
+
+    Proper definition of the StateTestWrapper is done during the
+    pytest_runtest_call.
     """
 
-    class StateTestWrapper:
-        spec = None
+    class StateTestWrapper(StateTest):
+        pass
 
-    return StateTestWrapper()
+    return StateTestWrapper
 
 
 @pytest.fixture(scope="function")
-def blockchain_test():
+def blockchain_test() -> BlockchainTestFiller:
     """
-    A fixture used to held define BlockchainTests analogous to the state_test
-    fixture for StateTests. See the state_test fixture docstring for details.
+    Fixture used to define an auto-fillable BlockchainTest analogous to the
+    state_test fixture for StateTests.
+    See the state_test fixture docstring for details.
     """
 
-    class BlockchainTestWrapper:
-        spec = None
+    class BlockchainTestWrapper(BlockchainTest):
+        pass
 
-    return BlockchainTestWrapper()
+    return BlockchainTestWrapper
 
 
 def convert_pytest_case_name_to_fixture_name(item):
@@ -174,11 +184,6 @@ def pytest_runtest_call(item):
     has executed the test function and created the test spec, we fill
     the test spec and write the generated fixture to file.
     """
-    output = yield  # Execute the test function
-
-    # Process test result; this will stop execution if there was an issue in
-    # the test function and trigger a pytest error or fail for this spec.
-    output.get_result()
 
     # Get config from session-wide fixtures. Note, we could also access these
     # from the pytest config object via item.config
@@ -191,35 +196,57 @@ def pytest_runtest_call(item):
     # Get test-specific params from potentially locally defined fixtures
     eips = item.funcargs["eips"]
     fork = item.funcargs["fork"]
-    if "state_test" in item.funcargs:
-        test_spec = item.funcargs["state_test"].spec
-    elif "blockchain_test" in item.funcargs:
-        test_spec = item.funcargs["blockchain_test"].spec
-    else:
-        # TODO: Raise custom exception instead of fail to trigger a
-        # pytest error
-        pytest.fail(
-            "Invalid test function signature: Test did not use either "
-            " of the 'state_test' or 'blockchain_test' fixtures."
-        )
 
     if not t8n.is_fork_supported(fork):
         pytest.skip(f"Fork '{fork}' not supported by t8n, skipped")
     if fork == ArrowGlacier:
         pytest.skip(f"Fork '{fork}' not supported by hive, skipped")
 
-    fixture_name = convert_pytest_case_name_to_fixture_name(item)
-    fixture_output = fill_test(
-        fixture_name,
-        t8n,
-        b11r,
-        test_spec,
-        fork,
-        engine,
-        reference_spec,
-        eips=eips,
-    )
-    write_fixture_file(item, fixture_output)
+    if "state_test" in item.funcargs:
+
+        class StateTestWrapper(StateTest):
+            def __init__(self, *args, **kwargs):
+                super(StateTestWrapper, self).__init__(*args, **kwargs)
+                fixture_name = convert_pytest_case_name_to_fixture_name(item)
+                fixture_output = fill_test(
+                    fixture_name,
+                    t8n,
+                    b11r,
+                    self,
+                    fork,
+                    engine,
+                    reference_spec,
+                    eips=eips,
+                )
+                write_fixture_file(item, fixture_output)
+
+        item.funcargs["state_test"] = StateTestWrapper
+
+    if "blockchain_test" in item.funcargs:
+
+        class BlockchainTestWrapper(StateTest):
+            def __init__(self, *args, **kwargs):
+                super(BlockchainTestWrapper, self).__init__(*args, **kwargs)
+                fixture_name = convert_pytest_case_name_to_fixture_name(item)
+                fixture_output = fill_test(
+                    fixture_name,
+                    t8n,
+                    b11r,
+                    self,
+                    fork,
+                    engine,
+                    reference_spec,
+                    eips=eips,
+                )
+                write_fixture_file(item, fixture_output)
+
+        item.funcargs["blockchain_test"] = BlockchainTestWrapper
+
+    output = yield  # Execute the test function
+
+    # Process test result; this will stop execution if there was an issue in
+    # the test function and trigger a pytest error or fail for this spec.
+    output.get_result()
 
 
 def write_fixture_file(item, fixture_output):

--- a/fillers/example/acl_example.py
+++ b/fillers/example/acl_example.py
@@ -7,11 +7,11 @@ import pytest
 from ethereum_test_forks import Berlin, Fork, London, forks_from_until, is_fork
 from ethereum_test_tools import AccessList, Account, Environment
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import StateTest, Transaction
+from ethereum_test_tools import StateTestFiller, Transaction
 
 
 @pytest.mark.parametrize("fork", forks_from_until(Berlin, London))
-def test_access_list(state_test, fork: Fork):
+def test_access_list(state_test: StateTestFiller, fork: Fork):
     """
     Test type 1 transaction.
     """
@@ -65,4 +65,4 @@ def test_access_list(state_test, fork: Fork):
             nonce=1,
         ),
     }
-    state_test.spec = StateTest(env=env, pre=pre, post=post, txs=[tx])
+    state_test(env=env, pre=pre, post=post, txs=[tx])

--- a/fillers/example/yul_example.py
+++ b/fillers/example/yul_example.py
@@ -8,7 +8,7 @@ from ethereum_test_forks import Berlin, Fork, forks_from
 from ethereum_test_tools import (
     Account,
     Environment,
-    StateTest,
+    StateTestFiller,
     TestAddress,
     Transaction,
     Yul,
@@ -16,7 +16,7 @@ from ethereum_test_tools import (
 
 
 @pytest.mark.parametrize("fork", forks_from(Berlin))
-def test_yul(state_test, fork: Fork):
+def test_yul(state_test: StateTestFiller, fork: Fork):
     """
     Test YUL compiled bytecode.
     """
@@ -59,4 +59,4 @@ def test_yul(state_test, fork: Fork):
         ),
     }
 
-    state_test.spec = StateTest(env=env, pre=pre, post=post, txs=[tx])
+    state_test(env=env, pre=pre, post=post, txs=[tx])

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -25,7 +25,12 @@ from .common import (
 from .filling.decorators import test_from, test_from_until, test_only
 from .filling.fill import fill_test
 from .reference_spec import ReferenceSpec, ReferenceSpecTypes
-from .spec import BlockchainTest, StateTest
+from .spec import (
+    BlockchainTest,
+    BlockchainTestFiller,
+    StateTest,
+    StateTestFiller,
+)
 from .vm import Opcode, Opcodes
 
 __all__ = (
@@ -33,6 +38,7 @@ __all__ = (
     "Account",
     "Block",
     "BlockchainTest",
+    "BlockchainTestFiller",
     "Code",
     "CodeGasMeasure",
     "Environment",
@@ -44,6 +50,7 @@ __all__ = (
     "ReferenceSpec",
     "ReferenceSpecTypes",
     "StateTest",
+    "StateTestFiller",
     "Storage",
     "TestAddress",
     "Transaction",

--- a/src/ethereum_test_tools/spec/__init__.py
+++ b/src/ethereum_test_tools/spec/__init__.py
@@ -2,15 +2,21 @@
 Test spec definitions and utilities.
 """
 from .base_test import BaseTest, TestSpec, verify_post_alloc
-from .blockchain_test import BlockchainTest, BlockchainTestSpec
-from .state_test import StateTest, StateTestSpec
+from .blockchain_test import (
+    BlockchainTest,
+    BlockchainTestFiller,
+    BlockchainTestSpec,
+)
+from .state_test import StateTest, StateTestFiller, StateTestSpec
 
 __all__ = (
     "BaseTest",
     "BlockchainTest",
+    "BlockchainTestFiller",
     "BlockchainTestSpec",
-    "TestSpec",
     "StateTest",
+    "StateTestFiller",
     "StateTestSpec",
+    "TestSpec",
     "verify_post_alloc",
 )

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -13,6 +13,7 @@ from typing import (
     Mapping,
     Optional,
     Tuple,
+    Type,
 )
 
 from ethereum_test_forks import Fork
@@ -285,3 +286,4 @@ class BlockchainTest(BaseTest):
 
 
 BlockchainTestSpec = Callable[[str], Generator[BlockchainTest, None, None]]
+BlockchainTestFiller = Type[BlockchainTest]

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -11,6 +11,7 @@ from typing import (
     Mapping,
     Optional,
     Tuple,
+    Type,
 )
 
 from ethereum_test_forks import Fork
@@ -176,3 +177,4 @@ class StateTest(BaseTest):
 
 
 StateTestSpec = Callable[[str], Generator[StateTest, None, None]]
+StateTestFiller = Type[StateTest]

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -237,3 +237,13 @@ staticcall
 revert
 invalid
 selfdestruct
+
+addoption
+autouse
+dest
+funcargs
+getgroup
+getoption
+hookimpl
+hookwrapper
+runtest


### PR DESCRIPTION
Based on suggestion by @spencer-tb, this PR implements another option for the signature of pytest based test functions.

It implements an filled-at-instantiation class that is defined right before the test function is called, and is tailored to the specific test function.