### PR TITLE
pytest: port eip spec version checking to a pytest plugin

### DIFF
--- a/fillers/conftest.py
+++ b/fillers/conftest.py
@@ -19,7 +19,6 @@ from ethereum_test_tools import (
     BlockchainTestFiller,
     Fixture,
     JSONEncoder,
-    ReferenceSpecTypes,
     StateTest,
     StateTestFiller,
     fill_test,
@@ -197,28 +196,6 @@ def eips():
     EIPs should be activated for the fillers in scope.
     """
     return []
-
-
-@pytest.fixture(autouse=True, scope="module")
-def reference_spec(request):
-    """
-    Returns the reference spec used for the generated test fixtures in a given
-    module.
-    """
-    module_dict = request.module.__dict__
-    parseable_ref_specs = [
-        ref_spec_type
-        for ref_spec_type in ReferenceSpecTypes
-        if ref_spec_type.parseable_from_module(module_dict)
-    ]
-    if len(parseable_ref_specs) > 0:
-        spec_obj = parseable_ref_specs[0].parse_from_module(module_dict)
-        # TODO: actually raise a warning if the reference spec is outdated
-        return spec_obj
-    else:
-        # TODO: raise a warning if no reference spec is found
-        pass
-    return None
 
 
 SPEC_TYPES: List[Type[BaseTest]] = [StateTest, BlockchainTest]

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,9 @@ testpaths =
     fillers/eips/eip3651.py
     fillers/eips/eip3855.py
     fillers/vm/chain_id.py
-addopts = -p pytest_plugins.latest_fork
+addopts = 
+    -p pytest_plugins.latest_fork
+    -p pytest_plugins.spec_version_checker
 markers =
     state_test: test cases that implement a single state transition test
     blockchain_test: test cases that implement block transition tests

--- a/src/pytest_plugins/spec_version_checker.py
+++ b/src/pytest_plugins/spec_version_checker.py
@@ -1,0 +1,81 @@
+"""
+A pytest plugin that checks that the spec version specified in test/filler
+modules matches that of https://github.com/ethereum/EIPs.
+"""
+import warnings
+
+import pytest
+
+from ethereum_test_tools import ReferenceSpec, ReferenceSpecTypes
+
+IGNORE_PACKAGES = [
+    "vm.",
+    "example.",
+    "security.",
+]
+
+
+class OutdatedReferenceSpec(Warning):
+    """
+    Warning when the spec version found in a filler module is out of date.
+    """
+
+    def __init__(self, filler_module: str, spec_obj: ReferenceSpec):
+        super().__init__(
+            "There is newer version of the spec referenced in filler "
+            f"{filler_module}, tests might be outdated: "
+            f"Spec: {spec_obj.name()}. "
+            "Referenced version: "
+            f"{spec_obj.known_version()}. "
+            "Latest version: "
+            f"{spec_obj.latest_version()}."
+        )
+
+
+class NoReferenceSpecDefined(Warning):
+    """
+    Warning when no spec version was found in a filler module.
+    """
+
+    def __init__(self, filler_module: str):
+        super().__init__(f"No reference spec defined in {filler_module}.")
+
+
+class UnableToCheckReferenceSpec(Warning):
+    """
+    Warnings when the current spec version can not be determined.
+    """
+
+    def __init__(self, filler_module: str, error: Exception):
+        super().__init__(
+            f"Reference spec could not be determined for "
+            f"{filler_module}: {error}."
+        )
+
+
+@pytest.fixture(autouse=True, scope="module")
+def reference_spec(request):
+    """
+    Returns the reference spec used for the generated test fixtures in a
+    given module.
+    """
+    module_dict = request.module.__dict__
+    parseable_ref_specs = [
+        ref_spec_type
+        for ref_spec_type in ReferenceSpecTypes
+        if ref_spec_type.parseable_from_module(module_dict)
+    ]
+    filler_module = request.module.__name__
+    if any(filler_module.startswith(package) for package in IGNORE_PACKAGES):
+        return None
+    if len(parseable_ref_specs) > 0:
+        spec_obj = parseable_ref_specs[0].parse_from_module(module_dict)
+        try:
+            if spec_obj.is_outdated():
+                warnings.warn(OutdatedReferenceSpec(filler_module, spec_obj))
+            return spec_obj
+        except Exception as e:
+            warnings.warn(UnableToCheckReferenceSpec(filler_module, e))
+            return None
+    warnings.warn(NoReferenceSpecDefined(filler_module))
+    return None


### PR DESCRIPTION
This PR ports the reference spec checking by implementing the functionality in a pytest plugin: `spec_version_checker`.

If the checks fail, they get reported as warnings in the pytest test summary. 

See for example the following two runs that report warnings that:
1. pytest was unable to check the spec version, and,
2. the spec version is missing/notprovided, respectively, out of date.

![image](https://github.com/danceratopz/execution-spec-tests/assets/91727015/504eed63-ea47-439a-a209-d9d8de0eca58)

There is no way from [pytest's exit codes](https://docs.pytest.org/en/latest/reference/exit-codes.html#exit-codes) to tell whether warnings were raised. If we want to be able to check whether these warnings are present, via CI, for example, we'd have to run pytest as:
```console
pytest -W error 
```
This won't run fillers though, as it's currently implemented, as the warning gets treated as an error in test setup. This will also treat all warnings in the test session as errors, with a bit more work, we could filter using our custom warnings using, for example,
```console
pytest -W error::NoReferenceSpecDefined
```
In general, however, the output using `-W error::` is very noisy as an error for **every test** is raised. The following is example output with `-x` (stop after first fail):
![image](https://github.com/danceratopz/execution-spec-tests/assets/91727015/b90792d5-0233-441f-be81-c04829c695cb)
