### PR TITLE
fillers: convert remaining fillers to pytest format

### DIFF
--- a/fillers/security/selfdestruct_balance_bug.py
+++ b/fillers/security/selfdestruct_balance_bug.py
@@ -8,23 +8,25 @@ To reproduce the bug fill the test with the most recent geth evm version.
 Then run the fixture output within a vulnerable geth version:
 v1.9.20 > geth >= v1.9.4
 """
+import pytest
 
-from ethereum_test_forks import Constantinople
+from ethereum_test_forks import Constantinople, Fork, forks_from
 from ethereum_test_tools import (
     Account,
     Block,
-    BlockchainTest,
+    BlockchainTestFiller,
     TestAddress,
     Transaction,
     Yul,
-    test_from,
     to_address,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 
-@test_from(fork=Constantinople)
-def test_tx_selfdestruct_balance_bug(_):
+@pytest.mark.parametrize("fork", forks_from(Constantinople))
+def test_tx_selfdestruct_balance_bug(
+    blockchain_test: BlockchainTestFiller, fork: Fork
+):
     """
     Checks balance of 0xaa after executing specific txs:
 
@@ -133,4 +135,4 @@ def test_tx_selfdestruct_balance_bug(_):
         to_address(0xAA): Account(storage={0: 0}),
     }
 
-    yield BlockchainTest(pre=pre, post=post, blocks=blocks)
+    blockchain_test(pre=pre, post=post, blocks=blocks)

--- a/fillers/vm/dup.py
+++ b/fillers/vm/dup.py
@@ -1,8 +1,6 @@
 """
 Test DUP opcodes
 """
-from typing import Dict, Union
-
 import pytest
 
 from ethereum_test_forks import Fork, Istanbul, forks_from
@@ -10,6 +8,7 @@ from ethereum_test_tools import (
     Account,
     Environment,
     StateTestFiller,
+    Storage,
     Transaction,
     to_address,
 )
@@ -101,9 +100,7 @@ def test_dup(state_test: StateTestFiller, fork: Fork):
         DUP1 copies the first element of the stack (0x10).
         DUP16 copies the 16th element of the stack (0x01).
         """
-        s: Dict[Union[str, int, bytes], Union[str, int, bytes]] = dict(
-            zip(range(1, 17), range(16, 0, -1))
-        )
+        s: Storage.StorageDictType = dict(zip(range(1, 17), range(16, 0, -1)))
         s[0] = 16 - i
 
         post[account] = Account(storage=s)

--- a/fillers/vm/dup.py
+++ b/fillers/vm/dup.py
@@ -1,20 +1,22 @@
 """
 Test DUP opcodes
 """
+from typing import Dict, Union
 
-from ethereum_test_forks import Istanbul
+import pytest
+
+from ethereum_test_forks import Fork, Istanbul, forks_from
 from ethereum_test_tools import (
     Account,
     Environment,
-    StateTest,
+    StateTestFiller,
     Transaction,
-    test_from,
     to_address,
 )
 
 
-@test_from(Istanbul)
-def test_dup(fork):
+@pytest.mark.parametrize("fork", forks_from(Istanbul))
+def test_dup(state_test: StateTestFiller, fork: Fork):
     """
     Test DUP1-DUP16 opcodes.
     Based on ethereum/tests: GeneralStateTests/VMTests/vmTests/dup
@@ -99,9 +101,11 @@ def test_dup(fork):
         DUP1 copies the first element of the stack (0x10).
         DUP16 copies the 16th element of the stack (0x01).
         """
-        s = dict(zip(range(1, 17), range(16, 0, -1)))
+        s: Dict[Union[str, int, bytes], Union[str, int, bytes]] = dict(
+            zip(range(1, 17), range(16, 0, -1))
+        )
         s[0] = 16 - i
 
         post[account] = Account(storage=s)
 
-    yield StateTest(env=env, pre=pre, post=post, txs=txs)
+    state_test(env=env, pre=pre, post=post, txs=txs)

--- a/fillers/withdrawals/withdrawals.py
+++ b/fillers/withdrawals/withdrawals.py
@@ -25,7 +25,6 @@ from ethereum_test_tools.vm.opcode import Opcodes as Op
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4895.md"
 REFERENCE_SPEC_VERSION = "81af3b60b632bc9c03513d1d137f25410e3f4d34"
 
-WITHDRAWALS_FORK = Shanghai
 pytestmark = pytest.mark.parametrize("fork", forks_from(Shanghai))
 
 ONE_GWEI = 10**9

--- a/fillers/withdrawals/withdrawals.py
+++ b/fillers/withdrawals/withdrawals.py
@@ -289,7 +289,7 @@ class TestMultipleWithdrawalsSameAddress:
                     withdrawals=[
                         Withdrawal(
                             index=i,
-                            validator=0,
+                            validator=i,
                             address=self.ADDRESSES[i % len(self.ADDRESSES)],
                             amount=1,
                         )

--- a/fillers/withdrawals/withdrawals.py
+++ b/fillers/withdrawals/withdrawals.py
@@ -2,19 +2,21 @@
 Test Withdrawal system-level operation
 """
 
-from typing import List
+from enum import Enum, unique
+from typing import Dict, List
 
-from ethereum_test_forks import Shanghai
+import pytest
+
+from ethereum_test_forks import Fork, Shanghai, forks_from
 from ethereum_test_tools import (
     Account,
     Block,
-    BlockchainTest,
+    BlockchainTestFiller,
     TestAddress,
     Transaction,
     Withdrawal,
     Yul,
     compute_create_address,
-    test_from,
     to_address,
     to_hash,
 )
@@ -24,6 +26,7 @@ REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4895.md"
 REFERENCE_SPEC_VERSION = "81af3b60b632bc9c03513d1d137f25410e3f4d34"
 
 WITHDRAWALS_FORK = Shanghai
+pytestmark = pytest.mark.parametrize("fork", forks_from(Shanghai))
 
 ONE_GWEI = 10**9
 
@@ -42,70 +45,101 @@ def set_withdrawal_index(
         w.index = start_index + i
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_use_value_in_tx(_):
+@pytest.mark.parametrize(
+    "test_case",
+    ["tx_in_withdrawals_block", "tx_after_withdrawals_block"],
+    ids=lambda x: x,
+)
+class TestUseValueInTx:
     """
-    Test sending a transaction from an address yet to receive a withdrawal
-    """
-    pre = {TestAddress: Account(balance=0)}
+    Test that the value from a withdrawal can be used in a transaction:
 
-    tx = Transaction(
+    1. tx_in_withdrawals_block:
+      Test that the withdrawal value can not be used by a transaction in
+      the same block as the withdrawal.
+
+    2. tx_after_withdrawals_block:
+      Test that the withdrawal value can be used by a transaction in the
+      subsequent block.
+    """
+
+    @pytest.fixture
+    def tx(self):  # noqa: D102
         # Transaction sent from the `TestAddress`, which has 0 balance at start
-        nonce=0,
-        gas_price=ONE_GWEI,
-        gas_limit=21000,
-        to=to_address(0x100),
-        data="0x",
-    )
-
-    withdrawal = Withdrawal(
-        index=0,
-        validator=0,
-        address=TestAddress,
-        amount=tx.gas_limit + 1,
-    )
-
-    blocks = [
-        Block(
-            txs=[tx.with_error("intrinsic gas too low: have 0, want 21000")],
-            withdrawals=[
-                withdrawal,
-            ],
-            exception="Transaction without funds",
+        return Transaction(
+            nonce=0,
+            gas_price=ONE_GWEI,
+            gas_limit=21000,
+            to=to_address(0x100),
+            data="0x",
         )
-    ]
 
-    yield BlockchainTest(
-        pre=pre,
-        post={},
-        blocks=blocks,
-    )
+    @pytest.fixture
+    def withdrawal(self, tx: Transaction):  # noqa: D102
+        return Withdrawal(
+            index=0,
+            validator=0,
+            address=TestAddress,
+            amount=tx.gas_limit + 1,
+        )
 
-    blocks = [
-        Block(
-            txs=[],
-            withdrawals=[
-                withdrawal,
-            ],
-        ),
-        Block(
-            txs=[tx],
-            withdrawals=[],
-        ),
-    ]
-    post = {
-        TestAddress: Account(balance=ONE_GWEI),
-    }
+    @pytest.fixture
+    def blocks(  # noqa: D102
+        self, tx: Transaction, withdrawal: Withdrawal, test_case
+    ):
+        if test_case == "tx_in_withdrawals_block":
+            return [
+                Block(
+                    txs=[
+                        tx.with_error(
+                            "intrinsic gas too low: have 0, want 21000"
+                        )
+                    ],
+                    withdrawals=[
+                        withdrawal,
+                    ],
+                    exception="Transaction without funds",
+                )
+            ]
+        if test_case == "tx_after_withdrawals_block":
+            return [
+                Block(
+                    txs=[],
+                    withdrawals=[
+                        withdrawal,
+                    ],
+                ),
+                Block(
+                    txs=[tx],
+                    withdrawals=[],
+                ),
+            ]
+        raise Exception("Invalid test case.")
 
-    yield BlockchainTest(
-        pre=pre,
-        post=post,
-        blocks=blocks,
-    )
+    @pytest.fixture
+    def post(self, test_case: str) -> Dict:  # noqa: D102
+        if test_case == "tx_in_withdrawals_block":
+            return {}
+        if test_case == "tx_after_withdrawals_block":
+            return {TestAddress: Account(balance=ONE_GWEI)}
+        raise Exception("Invalid test case.")
+
+    def test_use_value_in_tx(
+        self,
+        blockchain_test: BlockchainTestFiller,
+        post: dict,
+        blocks: List[Block],
+    ):
+        """
+        Test sending withdrawal value in a transaction.
+        """
+        pre = {TestAddress: Account(balance=0)}
+        blockchain_test(pre=pre, post=post, blocks=blocks)
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_use_value_in_contract(_):
+def test_use_value_in_contract(
+    blockchain_test: BlockchainTestFiller, fork: Fork
+):
     """
     Test sending value from contract that has not received a withdrawal
     """
@@ -156,15 +190,12 @@ def test_use_value_in_contract(_):
         ),
     }
 
-    yield BlockchainTest(
-        pre=pre,
-        post=post,
-        blocks=blocks,
-    )
+    blockchain_test(pre=pre, post=post, blocks=blocks)
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_balance_within_block(_):
+def test_balance_within_block(
+    blockchain_test: BlockchainTestFiller, fork: Fork
+):
     """
     Test Withdrawal balance increase within the same block,
     inside contract call.
@@ -222,19 +253,19 @@ def test_balance_within_block(_):
         )
     }
 
-    yield BlockchainTest(
-        pre=pre,
-        post=post,
-        blocks=blocks,
-    )
+    blockchain_test(pre=pre, post=post, blocks=blocks)
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_multiple_withdrawals_same_address(_):
+@pytest.mark.parametrize("test_case", ["single_block", "multiple_blocks"])
+class TestMultipleWithdrawalsSameAddress:
     """
-    Test Withdrawals can be done to the same address multiple times in
-    the same block.
+    Test that multiple withdrawals can be sent to the same address in:
+
+    1. A single block.
+
+    2. Multiple blocks.
     """
+
     ADDRESSES = [
         to_address(0x0),  # Zero address
         to_address(0x1),  # Pre-compiles
@@ -249,72 +280,74 @@ def test_multiple_withdrawals_same_address(_):
         to_address(2**160 - 1),
     ]
 
-    pre = {
-        TestAddress: Account(balance=1000000000000000000000, nonce=0),
-    }
-
-    for addr in ADDRESSES:
-        pre[addr] = Account(
-            code=SET_STORAGE,
-        )
-
-    # Many repeating withdrawals of the same accounts in the same block.
-    blocks = [
-        Block(
-            withdrawals=[
-                Withdrawal(
-                    index=i,
-                    validator=0,
-                    address=ADDRESSES[i % len(ADDRESSES)],
-                    amount=1,
+    @pytest.fixture
+    def blocks(self, test_case: str):  # noqa: D102
+        if test_case == "single_block":
+            # Many repeating withdrawals of the same accounts in the same
+            # block.
+            return [
+                Block(
+                    withdrawals=[
+                        Withdrawal(
+                            index=i,
+                            validator=0,
+                            address=self.ADDRESSES[i % len(self.ADDRESSES)],
+                            amount=1,
+                        )
+                        for i in range(len(self.ADDRESSES) * 16)
+                    ],
+                ),
+            ]
+        if test_case == "multiple_blocks":
+            # Similar test but now use multiple blocks each with multiple
+            # withdrawals to the same withdrawal address.
+            return [
+                Block(
+                    withdrawals=[
+                        Withdrawal(
+                            index=i * 16 + j,
+                            validator=i,
+                            address=self.ADDRESSES[i],
+                            amount=1,
+                        )
+                        for j in range(16)
+                    ],
                 )
-                for i in range(len(ADDRESSES) * 16)
-            ],
-        ),
-    ]
+                for i in range(len(self.ADDRESSES))
+            ]
+        raise Exception("Invalid test case.")
 
-    post = {}
+    def test_multiple_withdrawals_same_address(
+        self,
+        blockchain_test: BlockchainTestFiller,
+        fork: Fork,
+        test_case: str,
+        blocks: List[Block],
+    ):
+        """
+        Test Withdrawals can be done to the same address multiple times in
+        the same block.
+        """
+        pre = {
+            TestAddress: Account(balance=1000000000000000000000, nonce=0),
+        }
+        for addr in self.ADDRESSES:
+            pre[addr] = Account(
+                code=SET_STORAGE,
+            )
 
-    for addr in ADDRESSES:
-        post[addr] = Account(
-            balance=16 * ONE_GWEI,
-            storage={},
-        )
+        # Expected post is the same for both test cases.
+        post = {}
+        for addr in self.ADDRESSES:
+            post[addr] = Account(
+                balance=16 * ONE_GWEI,
+                storage={},
+            )
 
-    yield BlockchainTest(
-        pre=pre,
-        post=post,
-        blocks=blocks,
-    )
-
-    # Similar test but now use multiple blocks each with multiple withdrawals
-    # to the same withdrawal address.
-    # Expected post is exactly the same.
-    blocks = [
-        Block(
-            withdrawals=[
-                Withdrawal(
-                    index=i * 16 + j,
-                    validator=i,
-                    address=ADDRESSES[i],
-                    amount=1,
-                )
-                for j in range(16)
-            ],
-        )
-        for i in range(len(ADDRESSES))
-    ]
-
-    yield BlockchainTest(
-        pre=pre,
-        post=post,
-        blocks=blocks,
-        tag="multiple_blocks",
-    )
+        blockchain_test(pre=pre, post=post, blocks=blocks, tag=test_case)
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_many_withdrawals(_):
+def test_many_withdrawals(blockchain_test: BlockchainTestFiller, fork: Fork):
     """
     Test Withdrawals with a count of N withdrawals in a single block where
     N is a high number not expected to be seen in mainnet.
@@ -351,13 +384,14 @@ def test_many_withdrawals(_):
         ),
     ]
 
-    yield BlockchainTest(pre=pre, post=post, blocks=blocks)
+    blockchain_test(pre=pre, post=post, blocks=blocks)
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_self_destructing_account(_):
+def test_self_destructing_account(
+    blockchain_test: BlockchainTestFiller, fork: Fork
+):
     """
-    Test Withdrawals can be done to self-destructed accounts.
+    Test withdrawals can be done to self-destructed accounts.
     Account `0x100` self-destructs and sends all its balance to `0x200`.
     Then, a withdrawal is received at `0x100` with 99 wei.
     """
@@ -405,15 +439,20 @@ def test_self_destructing_account(_):
         ),
     }
 
-    yield BlockchainTest(
-        pre=pre,
-        post=post,
-        blocks=[block],
-    )
+    blockchain_test(pre=pre, post=post, blocks=[block])
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_newly_created_contract(_):
+@pytest.mark.parametrize(
+    "include_value_in_tx",
+    [False, True],
+    ids=["without_tx_value", "with_tx_value"],
+)
+def test_newly_created_contract(
+    blockchain_test: BlockchainTestFiller,
+    fork: Fork,
+    include_value_in_tx: bool,
+    request,
+):
     """
     Test Withdrawing to a newly created contract.
     """
@@ -459,21 +498,15 @@ def test_newly_created_contract(_):
             balance=ONE_GWEI,
         ),
     }
+    if include_value_in_tx:
+        tx.value = ONE_GWEI
+        post[created_contract].balance = 2 * ONE_GWEI
 
-    yield BlockchainTest(pre=pre, post=post, blocks=[block])
-
-    # Same test but include value in the contract creating transaction
-
-    tx.value = ONE_GWEI
-    post[created_contract].balance = 2 * ONE_GWEI
-
-    yield BlockchainTest(
-        pre=pre, post=post, blocks=[block], tag="with_tx_value"
-    )
+    tag = request.node.callspec.id.split("-")[0]  # remove fork; brittle
+    blockchain_test(pre=pre, post=post, blocks=[block], tag=tag)
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_no_evm_execution(_):
+def test_no_evm_execution(blockchain_test: BlockchainTestFiller, fork: Fork):
     """
     Test Withdrawals don't trigger EVM execution.
     """
@@ -558,95 +591,137 @@ def test_no_evm_execution(_):
         to_address(0x400): Account(storage={1: 1}),
     }
 
-    yield BlockchainTest(pre=pre, post=post, blocks=blocks)
+    blockchain_test(pre=pre, post=post, blocks=blocks)
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_zero_amount(_):
+@unique
+class ZeroAmountTestCases(Enum):  # noqa: D101
+    TWO_ZERO = "two_withdrawals_no_value"
+    THREE_ONE_WITH_VALUE = "three_withdrawals_one_with_value"
+    FOUR_ONE_WITH_MAX = "four_withdrawals_one_with_value_one_with_max"
+    FOUR_ONE_WITH_MAX_REVERSED = (
+        "four_withdrawals_one_with_value_one_with_max_reversed_order"
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [case for case in ZeroAmountTestCases],
+    ids=[case.value for case in ZeroAmountTestCases],
+)
+class TestZeroAmount:
     """
-    Test Withdrawals where one of the withdrawal has a zero amount.
+    Test withdrawals with zero amount for the following cases, all withdrawals
+    are included in one block:
+
+    1. Two withdrawals of zero amount to two different addresses; one to an
+       untouched account, one to an account with a balance.
+
+    2. As 1., but with an additional withdrawal with positive value.
+
+    3. As 2., but with an additional withdrawal containing the maximum value
+       possible.
+
+    4. As 3., but with order of withdrawals in the block reversed.
+
     """
-    pre = {
-        TestAddress: Account(balance=1000000000000000000000, nonce=0),
-        to_address(0x200): Account(
-            code="0x00",
-            balance=0,
-        ),
-    }
 
-    # Untouched account
-    withdrawal_1 = Withdrawal(
-        index=0,
-        validator=0,
-        address=to_address(0x100),
-        amount=0,
-    )
-    # Touched account
-    withdrawal_2 = Withdrawal(
-        index=0,
-        validator=0,
-        address=to_address(0x200),
-        amount=0,
-    )
+    @pytest.fixture(scope="function")
+    def test_case_parameters(self, test_case):  # noqa: D102
+        withdrawals = [
+            # No value, untouched account
+            Withdrawal(
+                index=0,
+                validator=0,
+                address=to_address(0x100),
+                amount=0,
+            ),
+            # No value, touched account
+            Withdrawal(
+                index=0,
+                validator=0,
+                address=to_address(0x200),
+                amount=0,
+            ),
+            # Withdrawal with value
+            Withdrawal(
+                index=1,
+                validator=0,
+                address=to_address(0x300),
+                amount=1,
+            ),
+            # Withdrawal with maximum amount
+            Withdrawal(
+                index=2,
+                validator=0,
+                address=to_address(0x400),
+                amount=2**64 - 1,
+            ),
+        ]
+        post = {
+            to_address(0x100): Account.NONEXISTENT,
+            to_address(0x200): Account(code="0x00", balance=0),
+            to_address(0x300): Account(balance=ONE_GWEI),
+            to_address(0x400): Account(balance=(2**64 - 1) * ONE_GWEI),
+        }
+        if test_case == ZeroAmountTestCases.TWO_ZERO:
+            return {
+                "withdrawals": withdrawals[0:2],
+                "post": {
+                    account: post[account]
+                    for account in post
+                    if account in [to_address(0x100), to_address(0x200)]
+                },
+            }
+        if test_case == ZeroAmountTestCases.THREE_ONE_WITH_VALUE:
+            return {
+                "withdrawals": withdrawals[0:3],
+                "post": {
+                    account: post[account]
+                    for account in post
+                    if account
+                    in [
+                        to_address(0x100),
+                        to_address(0x200),
+                        to_address(0x300),
+                    ]
+                },
+            }
+        if test_case == ZeroAmountTestCases.FOUR_ONE_WITH_MAX:
+            return {"withdrawals": withdrawals, "post": post}
+        if test_case == ZeroAmountTestCases.FOUR_ONE_WITH_MAX_REVERSED:
+            withdrawals.reverse()
+            set_withdrawal_index(withdrawals)
+            return {"withdrawals": withdrawals, "post": post}
+        raise Exception("Unknown test case.")
 
-    block = Block(
-        withdrawals=[withdrawal_1, withdrawal_2],
-    )
+    def test_zero_amount(
+        self,
+        blockchain_test: BlockchainTestFiller,
+        fork: Fork,
+        test_case: ZeroAmountTestCases,
+        test_case_parameters: Dict,
+    ):
+        """
+        Test Withdrawals where one of the withdrawal has a zero amount.
+        """
+        pre = {
+            TestAddress: Account(balance=1000000000000000000000, nonce=0),
+            to_address(0x200): Account(
+                code="0x00",
+                balance=0,
+            ),
+        }
 
-    post = {
-        to_address(0x100): Account.NONEXISTENT,
-        to_address(0x200): Account(
-            code="0x00",
-            balance=0,
-        ),
-    }
-
-    yield BlockchainTest(pre=pre, post=post, blocks=[block])
-
-    # Same test but add another withdrawal with positive amount in same
-    # block.
-    withdrawal_3 = Withdrawal(
-        index=1,
-        validator=0,
-        address=to_address(0x300),
-        amount=1,
-    )
-    block.withdrawals.append(withdrawal_3)
-    post[to_address(0x300)] = Account(
-        balance=ONE_GWEI,
-    )
-    yield BlockchainTest(
-        pre=pre, post=post, blocks=[block], tag="with_extra_positive_amount"
-    )
-
-    # Same test but add another withdrawal with max amount in same
-    # block.
-    withdrawal_4 = Withdrawal(
-        index=2,
-        validator=0,
-        address=to_address(0x400),
-        amount=2**64 - 1,
-    )
-    block.withdrawals.append(withdrawal_4)
-    post[to_address(0x400)] = Account(
-        balance=(2**64 - 1) * ONE_GWEI,
-    )
-
-    yield BlockchainTest(
-        pre=pre, post=post, blocks=[block], tag="with_extra_max_amount"
-    )
-
-    # Same test but reverse order of withdrawals.
-    block.withdrawals.reverse()
-    set_withdrawal_index(block.withdrawals)
-
-    yield BlockchainTest(
-        pre=pre, post=post, blocks=[block], tag="reverse_withdrawal_order"
-    )
+        blockchain_test(
+            pre=pre,
+            post=test_case_parameters["post"],
+            blocks=[Block(withdrawals=test_case_parameters["withdrawals"])],
+            tag=test_case.value,
+        )
 
 
-@test_from(WITHDRAWALS_FORK)
-def test_large_amount(_):
+def test_large_amount(blockchain_test: BlockchainTestFiller, fork: Fork):
     """
     Test Withdrawals that have a large gwei amount, so that (gwei * 1e9)
     could overflow uint64 but not uint256.
@@ -683,8 +758,4 @@ def test_large_amount(_):
             withdrawals=withdrawals,
         )
     ]
-    yield BlockchainTest(
-        pre=pre,
-        post=post,
-        blocks=blocks,
-    )
+    blockchain_test(pre=pre, post=post, blocks=blocks)

--- a/fillers/withdrawals/withdrawals.py
+++ b/fillers/withdrawals/withdrawals.py
@@ -29,9 +29,6 @@ pytestmark = pytest.mark.parametrize("fork", forks_from(Shanghai))
 
 ONE_GWEI = 10**9
 
-# Common contract that sets a storage value unconditionally on call
-SET_STORAGE = Op.SSTORE(Op.NUMBER, 1)
-
 
 def set_withdrawal_index(
     withdrawals: List[Withdrawal], start_index: int = 0
@@ -332,7 +329,8 @@ class TestMultipleWithdrawalsSameAddress:
         }
         for addr in self.ADDRESSES:
             pre[addr] = Account(
-                code=SET_STORAGE,
+                # set a storage value unconditionally on call
+                code=Op.SSTORE(Op.NUMBER, 1),
             )
 
         # Expected post is the same for both test cases.
@@ -361,7 +359,7 @@ def test_many_withdrawals(blockchain_test: BlockchainTestFiller, fork: Fork):
         addr = to_address(0x100 * i)
         amount = i * 1
         pre[addr] = Account(
-            code=SET_STORAGE,
+            code=Op.SSTORE(Op.NUMBER, 1),
         )
         withdrawals.append(
             Withdrawal(
@@ -372,7 +370,7 @@ def test_many_withdrawals(blockchain_test: BlockchainTestFiller, fork: Fork):
             )
         )
         post[addr] = Account(
-            code=SET_STORAGE,
+            code=Op.SSTORE(Op.NUMBER, 1),
             balance=amount * ONE_GWEI,
             storage={},
         )
@@ -512,16 +510,16 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller, fork: Fork):
     pre = {
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
         to_address(0x100): Account(
-            code=SET_STORAGE,
+            code=Op.SSTORE(Op.NUMBER, 1),
         ),
         to_address(0x200): Account(
-            code=SET_STORAGE,
+            code=Op.SSTORE(Op.NUMBER, 1),
         ),
         to_address(0x300): Account(
-            code=SET_STORAGE,
+            code=Op.SSTORE(Op.NUMBER, 1),
         ),
         to_address(0x400): Account(
-            code=SET_STORAGE,
+            code=Op.SSTORE(Op.NUMBER, 1),
         ),
     }
     blocks = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,12 +1,9 @@
 [pytest]
 console_output_style = count
 minversion = 7.0
-testpaths =
-    fillers/example
-    fillers/eips/eip3651.py
-    fillers/eips/eip3855.py
-    fillers/eips/eip3860.py
-    fillers/vm/chain_id.py
+python_files = *.py
+testpaths = fillers/
+norecursedirs = fillers/eips/eip4844
 addopts = 
     -p pytest_plugins.latest_fork
     -p pytest_plugins.spec_version_checker

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -246,6 +246,7 @@ selfdestruct
 addoption
 argname
 autouse
+callspec
 dest
 fixturenames
 funcargs


### PR DESCRIPTION
Convert the remaining following fillers to pytest format:
- withdrawals/withdrawals.py
- vm/dup.py
- security/selfdestruct_balance_bug.py

Experimented with a couple of new patterns for test/fixture code organization in withdrawals, in particular in `TestZeroValue`:
- Use an enum class to define test case names.
- Combine test case parameters in one fixture `test_case_parameters` that returns a dict with the aim of keeping the definition of parameters that make up a test case together.