### PR TITLE
pytest: add fork_transition_test marker

### DIFF
--- a/fillers/eips/eip4844/excess_data_gas_fork_transition.py
+++ b/fillers/eips/eip4844/excess_data_gas_fork_transition.py
@@ -23,7 +23,7 @@ REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4844.md"
 REFERENCE_SPEC_VERSION = "ac003985b9be74ff48bd897770e6d5f2e4318715"
 
 # All tests run on the transition fork from Shanghai to Cancun
-pytestmark = pytest.mark.fork_transition_test("Cancun")
+pytestmark = pytest.mark.valid_at_transition_to("Cancun")
 
 BLOB_COMMITMENT_VERSION_KZG = 1
 DATAHASH_GAS_COST = 3

--- a/fillers/eips/eip4844/excess_data_gas_fork_transition.py
+++ b/fillers/eips/eip4844/excess_data_gas_fork_transition.py
@@ -23,7 +23,7 @@ REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4844.md"
 REFERENCE_SPEC_VERSION = "ac003985b9be74ff48bd897770e6d5f2e4318715"
 
 # All tests run on the transition fork from Shanghai to Cancun
-pytestmark = pytest.mark.valid_from("ShanghaiToCancunAtTime15k")
+pytestmark = pytest.mark.fork_transition_test("Cancun")
 
 BLOB_COMMITMENT_VERSION_KZG = 1
 DATAHASH_GAS_COST = 3

--- a/fillers/eips/eip4844/point_evaluation_precompile.py
+++ b/fillers/eips/eip4844/point_evaluation_precompile.py
@@ -575,7 +575,7 @@ def test_point_evaluation_precompile_gas_tx_to(
     [[Z, 0, INF_POINT, INF_POINT, auto]],
     ids=["correct_proof"],
 )
-@pytest.mark.valid_from("ShanghaiToCancunAtTime15k")
+@pytest.mark.fork_transition_test("Cancun")
 def test_point_evaluation_precompile_before_fork(
     blockchain_test: BlockchainTestFiller,
     pre: Dict,

--- a/fillers/eips/eip4844/point_evaluation_precompile.py
+++ b/fillers/eips/eip4844/point_evaluation_precompile.py
@@ -575,7 +575,7 @@ def test_point_evaluation_precompile_gas_tx_to(
     [[Z, 0, INF_POINT, INF_POINT, auto]],
     ids=["correct_proof"],
 )
-@pytest.mark.fork_transition_test("Cancun")
+@pytest.mark.valid_at_transition_to("Cancun")
 def test_point_evaluation_precompile_before_fork(
     blockchain_test: BlockchainTestFiller,
     pre: Dict,

--- a/fillers/vm/dup.py
+++ b/fillers/vm/dup.py
@@ -1,8 +1,6 @@
 """
 Test DUP opcodes
 """
-import pytest
-
 from ethereum_test_tools import (
     Account,
     Environment,
@@ -13,7 +11,6 @@ from ethereum_test_tools import (
 )
 
 
-@pytest.mark.valid_from("Istanbul")
 def test_dup(state_test: StateTestFiller):
     """
     Test DUP1-DUP16 opcodes.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,9 @@
 console_output_style = count
 minversion = 7.0
 python_files = *.py
-testpaths = fillers/
+testpaths =
+    fillers/
+    fillers/eips/eip4844/excess_data_gas_fork_transition.py
 norecursedirs = fillers/eips/eip4844
 addopts = 
     -p pytest_plugins.test_filler
@@ -11,6 +13,6 @@ addopts =
 markers =
     state_test: test cases that implement a single state transition test
     blockchain_test: test cases that implement block transition tests
-    valid_only_for(fork): specifies a test case is only valid for a single fork
+    fork_transition_test(fork_to): specifies a test case that runs on a fork transition boundary to the specified fork
     valid_from(fork): specifies from which fork a test case is valid
     valid_until(fork): specifies until which fork a test case is valid

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,6 @@ addopts =
 markers =
     state_test: test cases that implement a single state transition test
     blockchain_test: test cases that implement block transition tests
-    fork_transition_test(fork_to): specifies a test case that runs on a fork transition boundary to the specified fork
+    valid_at_transition_to(fork): specifies a test case is valid only at fork transition boundary to the specified fork
     valid_from(fork): specifies from which fork a test case is valid
     valid_until(fork): specifies until which fork a test case is valid

--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -26,6 +26,7 @@ from .forks.transition import (
 from .forks.upcoming import Cancun
 from .helpers import (
     InvalidForkError,
+    all_transition_forks,
     fork_only,
     forks_from,
     forks_from_until,
@@ -33,6 +34,8 @@ from .helpers import (
     latest_fork_resolver,
     set_latest_fork,
     set_latest_fork_by_name,
+    transition_fork_from_to,
+    transition_fork_to,
 )
 
 __all__ = [
@@ -55,6 +58,7 @@ __all__ = [
     "Shanghai",
     "ShanghaiToCancunAtTime15k",
     "Cancun",
+    "all_transition_forks",
     "fork_only",
     "forks_from",
     "forks_from_until",
@@ -62,4 +66,6 @@ __all__ = [
     "latest_fork_resolver",
     "set_latest_fork",
     "set_latest_fork_by_name",
+    "transition_fork_from_to",
+    "transition_fork_to",
 ]

--- a/src/ethereum_test_forks/helpers.py
+++ b/src/ethereum_test_forks/helpers.py
@@ -4,7 +4,7 @@ Helper methods to resolve forks during test filling
 from typing import List
 
 from .base_fork import BaseFork, Fork
-from .forks import forks, upcoming
+from .forks import forks, transition, upcoming
 from .transition_base_fork import TransitionBaseClass
 
 
@@ -55,6 +55,54 @@ def get_parent_fork(fork: Fork) -> Fork:
     Returns the parent fork of the specified fork
     """
     return fork.__base__
+
+
+def all_transition_forks() -> List[Fork]:
+    """
+    Returns all the transition forks
+    """
+    transition_forks: List[Fork] = []
+
+    for fork_name in transition.__dict__:
+        fork = transition.__dict__[fork_name]
+        if not isinstance(fork, type):
+            continue
+        if issubclass(fork, TransitionBaseClass) and issubclass(
+            fork, BaseFork
+        ):
+            transition_forks.append(fork)
+
+    return transition_forks
+
+
+def transition_fork_from_to(fork_from: Fork, fork_to: Fork) -> Fork | None:
+    """
+    Returns the transition fork that transition to and from the specified forks
+    """
+    for transition_fork in all_transition_forks():
+        if not issubclass(transition_fork, TransitionBaseClass):
+            continue
+        if (
+            transition_fork.transitions_to() == fork_to
+            and transition_fork.transitions_from() == fork_from
+        ):
+            return transition_fork
+
+    return None
+
+
+def transition_fork_to(fork_to: Fork) -> List[Fork]:
+    """
+    Returns the transition fork that transition to and from the specified forks
+    """
+    transition_forks: List[Fork] = []
+    for transition_fork in all_transition_forks():
+        if not issubclass(transition_fork, TransitionBaseClass):
+            continue
+        if transition_fork.transitions_to() == fork_to:
+            transition_forks.append(transition_fork)
+
+    return transition_forks
 
 
 def forks_from_until(fork_from: Fork, fork_until: Fork) -> List[Fork]:

--- a/src/ethereum_test_forks/helpers.py
+++ b/src/ethereum_test_forks/helpers.py
@@ -77,7 +77,8 @@ def all_transition_forks() -> List[Fork]:
 
 def transition_fork_from_to(fork_from: Fork, fork_to: Fork) -> Fork | None:
     """
-    Returns the transition fork that transitions to and from the specified forks.
+    Returns the transition fork that transitions to and from the specified
+    forks.
     """
     for transition_fork in all_transition_forks():
         if not issubclass(transition_fork, TransitionBaseClass):

--- a/src/ethereum_test_forks/helpers.py
+++ b/src/ethereum_test_forks/helpers.py
@@ -77,7 +77,7 @@ def all_transition_forks() -> List[Fork]:
 
 def transition_fork_from_to(fork_from: Fork, fork_to: Fork) -> Fork | None:
     """
-    Returns the transition fork that transition to and from the specified forks
+    Returns the transition fork that transitions to and from the specified forks.
     """
     for transition_fork in all_transition_forks():
         if not issubclass(transition_fork, TransitionBaseClass):
@@ -93,7 +93,7 @@ def transition_fork_from_to(fork_from: Fork, fork_to: Fork) -> Fork | None:
 
 def transition_fork_to(fork_to: Fork) -> List[Fork]:
     """
-    Returns the transition fork that transition to and from the specified forks
+    Returns the transition fork that transitions to the specified fork.
     """
     transition_forks: List[Fork] = []
     for transition_fork in all_transition_forks():

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -18,7 +18,22 @@ from ..helpers import (
     forks_from_until,
     is_fork,
     set_latest_fork_by_name,
+    transition_fork_from_to,
+    transition_fork_to,
 )
+
+
+def test_transition_forks():
+    """
+    Test transition fork utilities.
+    """
+    assert transition_fork_from_to(Berlin, London) == BerlinToLondonAt5
+    assert transition_fork_from_to(Berlin, Merge) is None
+    assert transition_fork_to(Shanghai) == [MergeToShanghaiAtTime15k]
+
+    # Test forks transitioned to and from
+    assert BerlinToLondonAt5.transitions_to() == London
+    assert BerlinToLondonAt5.transitions_from() == Berlin
 
 
 def test_forks():

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -18,6 +18,13 @@ class TransitionBaseClass:
         """
         raise Exception("Not implemented")
 
+    @classmethod
+    def transitions_from(cls) -> Fork:
+        """
+        Returns the fork where the transition starts.
+        """
+        raise Exception("Not implemented")
+
 
 def transition_fork(to_fork: Fork):
     """
@@ -36,6 +43,9 @@ def transition_fork(to_fork: Fork):
                 return transition_name
 
         NewTransitionClass.transitions_to = lambda: to_fork  # type: ignore
+        NewTransitionClass.transitions_from = (  # type: ignore
+            lambda: cls.__bases__[0]
+        )
 
         return NewTransitionClass
 

--- a/src/pytest_plugins/forks.py
+++ b/src/pytest_plugins/forks.py
@@ -213,10 +213,10 @@ def pytest_generate_tests(metafunc):
     """
     Pytest hook used to dynamically generate test cases.
     """
-    fork_transition_test = [
+    valid_at_transition_to = [
         marker.args[0]
         for marker in metafunc.definition.iter_markers(
-            name="fork_transition_test"
+            name="valid_at_transition_to"
         )
     ]
     valid_from = [
@@ -227,23 +227,23 @@ def pytest_generate_tests(metafunc):
         marker.args[0]
         for marker in metafunc.definition.iter_markers(name="valid_until")
     ]
-    if fork_transition_test and (valid_from or valid_until):
+    if valid_at_transition_to and (valid_from or valid_until):
         pytest.fail(
             "The test function "
             f"{metafunc.function.__name__} specifies both a "
-            "pytest.mark.fork_transition_test and a pytest.mark.valid_from or "
+            "pytest.mark.valid_at_transition_to and a pytest.mark.valid_from or "
             "pytest.mark.valid_until marker. "
         )
 
     intersection_range = []
 
-    if fork_transition_test:
-        fork_to = fork_transition_test[0]
+    if valid_at_transition_to:
+        fork_to = valid_at_transition_to[0]
         if fork_to not in metafunc.config.fork_names:
             pytest.fail(
                 "The test function "
                 f"{metafunc.function.__name__} specifies an invalid fork "
-                f"{fork_to} to the pytest.mark.fork_transition_test marker. "
+                f"{fork_to} to the pytest.mark.valid_at_transition_to marker. "
             )
         if fork_to in metafunc.config.fork_range:
             to_fork = metafunc.config.fork_map[fork_to]

--- a/src/pytest_plugins/forks.py
+++ b/src/pytest_plugins/forks.py
@@ -231,8 +231,8 @@ def pytest_generate_tests(metafunc):
         pytest.fail(
             "The test function "
             f"{metafunc.function.__name__} specifies both a "
-            "pytest.mark.valid_at_transition_to and a pytest.mark.valid_from or "
-            "pytest.mark.valid_until marker. "
+            "pytest.mark.valid_at_transition_to and a pytest.mark.valid_from "
+            "or pytest.mark.valid_until marker. "
         )
 
     intersection_range = []


### PR DESCRIPTION
This PR suggests a marker for fork transition tests named "fork_transition_test" which can be added to a test to signal that it should run on the fork transition boundary to the specified fork.

It also adds the possibility to not require any marker at all, which signals that the test should can run from the first fork (Frontier) until the latest fork available.
An example is the dup.py test, where all fork validity markers have been removed and the test now runs without limitations on all forks.

We could also remove "if fork_transition_test and (valid_from or valid_until):" check in order to allow fork transition tests to be placed within the same file as other tests where a global `pytestmark = pytest.mark.valid_from` has been specified.