### PR TITLE
Changes to Fork library

### DIFF
--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -2,7 +2,7 @@
 Ethereum test fork definitions.
 """
 
-from .base_fork import SOLC_VERSION_TO_SUPPORTED_FORKS, Fork, ForkAttribute
+from .base_fork import Fork, ForkAttribute
 from .forks.forks import (
     ArrowGlacier,
     Berlin,
@@ -40,7 +40,6 @@ from .helpers import (
 )
 
 __all__ = [
-    "SOLC_VERSION_TO_SUPPORTED_FORKS",
     "Fork",
     "ForkAttribute",
     "ArrowGlacier",

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -8,28 +8,6 @@ from semver import Version
 
 from .base_decorators import prefer_transition_to_method
 
-SOLC_FORKS_0_8_20 = [
-    "homestead",
-    "tangerineWhistle",
-    "spuriousDragon",
-    "byzantium",
-    "constantinople",
-    "petersburg",
-    "istanbul",
-    "berlin",
-    "london",
-    "paris",
-    "shanghai",
-]
-SOLC_VERSION_TO_SUPPORTED_FORKS = {
-    Version.parse("0.8.20"): SOLC_FORKS_0_8_20,
-    Version.parse("0.8.21"): SOLC_FORKS_0_8_20,
-    Version.parse("0.8.22"): SOLC_FORKS_0_8_20,
-    Version.parse("0.8.23"): SOLC_FORKS_0_8_20,
-    # TBA: 0.8.24 is the current dev version.
-    Version.parse("0.8.24"): SOLC_FORKS_0_8_20,
-}
-
 
 class ForkAttribute(Protocol):
     """
@@ -283,14 +261,12 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         pass
 
     @classmethod
-    def is_supported_by_solc(cls, version: Version) -> bool:
+    @abstractmethod
+    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
         """
-        Returns True if the fork is supported by solc (--evm-version).
+        Returns the minimum version of solc that supports this fork.
         """
-        assert (
-            version in SOLC_VERSION_TO_SUPPORTED_FORKS.keys()
-        ), f"Unsupported solc version: {version}"
-        return cls.solc_name() in SOLC_VERSION_TO_SUPPORTED_FORKS[version]
+        pass
 
     @classmethod
     def blockchain_test_network_name(cls) -> str:

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -3,11 +3,13 @@ All Ethereum fork class definitions.
 """
 from typing import List, Mapping, Optional
 
+from semver import Version
+
 from ..base_fork import BaseFork
 
 
 # All forks must be listed here !!! in the order they were introduced !!!
-class Frontier(BaseFork, solc_name=None):
+class Frontier(BaseFork, solc_name="homestead"):
     """
     Frontier fork
     """
@@ -28,7 +30,14 @@ class Frontier(BaseFork, solc_name=None):
         """
         if cls._solc_name is not None:
             return cls._solc_name
-        return cls.name()
+        return cls.name().lower()
+
+    @classmethod
+    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+        """
+        Returns the minimum version of solc that supports this fork.
+        """
+        return Version.parse("0.8.20")
 
     @classmethod
     def header_base_fee_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:
@@ -150,7 +159,7 @@ class Frontier(BaseFork, solc_name=None):
         return {}
 
 
-class Homestead(Frontier, solc_name="homestead"):
+class Homestead(Frontier):
     """
     Homestead fork
     """
@@ -163,7 +172,7 @@ class Homestead(Frontier, solc_name="homestead"):
         return [1, 2, 3, 4] + super(Homestead, cls).precompiles(block_number, timestamp)
 
 
-class Byzantium(Homestead, solc_name="byzantium"):
+class Byzantium(Homestead):
     """
     Byzantium fork
     """
@@ -186,7 +195,7 @@ class Byzantium(Homestead, solc_name="byzantium"):
         return [5, 6, 7, 8] + super(Byzantium, cls).precompiles(block_number, timestamp)
 
 
-class Constantinople(Byzantium, solc_name="constantinople"):
+class Constantinople(Byzantium):
     """
     Constantinople fork
     """
@@ -208,7 +217,7 @@ class ConstantinopleFix(Constantinople, solc_name="constantinople"):
     pass
 
 
-class Istanbul(ConstantinopleFix, solc_name="istanbul"):
+class Istanbul(ConstantinopleFix):
     """
     Istanbul fork
     """
@@ -222,7 +231,7 @@ class Istanbul(ConstantinopleFix, solc_name="istanbul"):
 
 
 # Glacier forks skipped, unless explicitly specified
-class MuirGlacier(Istanbul):
+class MuirGlacier(Istanbul, solc_name="istanbul"):
     """
     Muir Glacier fork
     """
@@ -230,7 +239,7 @@ class MuirGlacier(Istanbul):
     pass
 
 
-class Berlin(Istanbul, solc_name="berlin"):
+class Berlin(Istanbul):
     """
     Berlin fork
     """
@@ -243,7 +252,7 @@ class Berlin(Istanbul, solc_name="berlin"):
         return [1] + super(Berlin, cls).tx_types(block_number, timestamp)
 
 
-class London(Berlin, solc_name="london"):
+class London(Berlin):
     """
     London fork
     """
@@ -264,7 +273,7 @@ class London(Berlin, solc_name="london"):
 
 
 # Glacier forks skipped, unless explicitly specified
-class ArrowGlacier(London):
+class ArrowGlacier(London, solc_name="london"):
     """
     Arrow Glacier fork
     """
@@ -272,7 +281,7 @@ class ArrowGlacier(London):
     pass
 
 
-class GrayGlacier(ArrowGlacier):
+class GrayGlacier(ArrowGlacier, solc_name="london"):
     """
     Gray Glacier fork
     """
@@ -282,7 +291,6 @@ class GrayGlacier(ArrowGlacier):
 
 class Paris(
     London,
-    solc_name="paris",
     transition_tool_name="Merge",
     blockchain_test_network_name="Merge",
 ):
@@ -321,7 +329,7 @@ class Paris(
         return 1
 
 
-class Shanghai(Paris, solc_name="shanghai"):
+class Shanghai(Paris):
     """
     Shanghai fork
     """
@@ -343,7 +351,7 @@ class Shanghai(Paris, solc_name="shanghai"):
         return 2
 
 
-class Cancun(Shanghai, solc_name="cancun"):
+class Cancun(Shanghai):
     """
     Cancun fork
     """
@@ -355,6 +363,13 @@ class Cancun(Shanghai, solc_name="cancun"):
         development.
         """
         return False
+
+    @classmethod
+    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+        """
+        Returns the minimum version of solc that supports this fork.
+        """
+        return Version.parse("0.8.24")
 
     @classmethod
     def header_excess_blob_gas_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -4,15 +4,19 @@ Test fork utilities.
 
 from typing import Mapping, cast
 
+from semver import Version
+
 from ..base_fork import Fork
 from ..forks.forks import Berlin, Cancun, Frontier, London, Paris, Shanghai
 from ..forks.transition import BerlinToLondonAt5, ParisToShanghaiAtTime15k
 from ..helpers import (
     forks_from,
     forks_from_until,
+    get_closest_fork_with_solc_support,
     get_deployed_forks,
     get_development_forks,
     get_forks,
+    get_forks_with_solc_support,
     transition_fork_from_to,
     transition_fork_to,
 )
@@ -214,3 +218,14 @@ def test_precompiles():
 
 def test_tx_types():
     Cancun.tx_types() == list(range(4))
+
+
+def test_solc_versioning():
+    assert len(get_forks_with_solc_support(Version.parse("0.8.20"))) == 13
+    assert len(get_forks_with_solc_support(Version.parse("0.8.24"))) > 13
+
+
+def test_closest_fork_supported_by_solc():
+    assert get_closest_fork_with_solc_support(Paris, Version.parse("0.8.20")) == Paris
+    assert get_closest_fork_with_solc_support(Cancun, Version.parse("0.8.20")) == Shanghai
+    assert get_closest_fork_with_solc_support(Cancun, Version.parse("0.8.24")) == Cancun

--- a/src/ethereum_test_tools/code/__init__.py
+++ b/src/ethereum_test_tools/code/__init__.py
@@ -3,10 +3,9 @@ Code related utilities and classes.
 """
 from .code import Code
 from .generators import CalldataCase, Case, CodeGasMeasure, Conditional, Initcode, Switch
-from .yul import SOLC_SUPPORTED_VERSIONS, Yul, YulCompiler
+from .yul import Yul, YulCompiler
 
 __all__ = (
-    "SOLC_SUPPORTED_VERSIONS",
     "Case",
     "CalldataCase",
     "Code",

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -11,14 +11,12 @@ from typing import Optional, Sized, SupportsBytes, Tuple, Type, Union
 
 from semver import Version
 
-from ethereum_test_forks import SOLC_VERSION_TO_SUPPORTED_FORKS, Fork
+from ethereum_test_forks import Fork
 
 from ..common.conversions import to_bytes
 from .code import Code
 
 DEFAULT_SOLC_ARGS = ("--assemble", "-")
-
-SOLC_SUPPORTED_VERSIONS = list(SOLC_VERSION_TO_SUPPORTED_FORKS.keys())
 
 
 def get_evm_version_from_fork(fork: Fork | None):

--- a/src/ethereum_test_tools/tests/conftest.py
+++ b/src/ethereum_test_tools/tests/conftest.py
@@ -5,7 +5,9 @@ Common pytest fixtures for ethereum_test_tools tests.
 import pytest
 from semver import Version
 
-from ..code import SOLC_SUPPORTED_VERSIONS, Yul
+from ethereum_test_forks import Frontier
+
+from ..code import Yul
 
 SOLC_PADDING_VERSION = Version.parse("0.8.21")
 
@@ -14,6 +16,6 @@ SOLC_PADDING_VERSION = Version.parse("0.8.21")
 def solc_version() -> Version:
     """Return the version of solc being used for tests."""
     solc_version = Yul("").version().finalize_version()
-    if solc_version not in SOLC_SUPPORTED_VERSIONS:
+    if solc_version < Frontier.solc_min_version():
         raise Exception("Unsupported solc version: {}".format(solc_version))
     return solc_version

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -8,26 +8,10 @@ from typing import Mapping, SupportsBytes
 import pytest
 from semver import Version
 
-from ethereum_test_forks import (
-    Fork,
-    Homestead,
-    Shanghai,
-    forks_from_until,
-    get_deployed_forks,
-    get_forks_with_solc_support,
-)
+from ethereum_test_forks import Fork, Homestead, Shanghai, get_deployed_forks
 from evm_transition_tool import FixtureFormats, GethTransitionTool
 
-from ..code import (
-    SOLC_SUPPORTED_VERSIONS,
-    CalldataCase,
-    Case,
-    Code,
-    Conditional,
-    Initcode,
-    Switch,
-    Yul,
-)
+from ..code import CalldataCase, Case, Code, Conditional, Initcode, Switch, Yul
 from ..common import Account, Environment, TestAddress, Transaction, to_hash_bytes
 from ..spec import StateTest
 from ..vm.opcode import Opcodes as Op
@@ -65,7 +49,7 @@ def test_code_operations(code: Code, expected_bytes: bytes):
     assert bytes(code) == expected_bytes
 
 
-@pytest.fixture(params=get_forks_with_solc_support(SOLC_SUPPORTED_VERSIONS[-1]))
+@pytest.fixture(params=get_deployed_forks())
 def fork(request: pytest.FixtureRequest):
     """
     Return the target evm-version (fork) for solc compilation.
@@ -97,7 +81,7 @@ def expected_bytes(request: pytest.FixtureRequest, solc_version: Version, fork: 
     """Return the expected bytes for the test."""
     expected_bytes = request.param
     if isinstance(expected_bytes, Template):
-        if solc_version < SOLC_PADDING_VERSION or fork == Homestead:
+        if solc_version < SOLC_PADDING_VERSION or fork <= Homestead:
             solc_padding = ""
         else:
             solc_padding = "00"
@@ -105,7 +89,7 @@ def expected_bytes(request: pytest.FixtureRequest, solc_version: Version, fork: 
     if isinstance(expected_bytes, bytes):
         if fork == Shanghai:
             expected_bytes = b"\x5f" + expected_bytes[2:]
-        if solc_version < SOLC_PADDING_VERSION or fork == Homestead:
+        if solc_version < SOLC_PADDING_VERSION or fork <= Homestead:
             return expected_bytes
         else:
             return expected_bytes + b"\x00"

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -353,7 +353,7 @@ def yul(fork: Fork, request):
     Test cases can override the default value by specifying a fixed version
     with the @pytest.mark.compile_yul_with(FORK) marker.
     """
-    solc_target_fork: Fork
+    solc_target_fork: Fork | None
     marker = request.node.get_closest_marker("compile_yul_with")
     if marker:
         if not marker.args[0]:

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -364,6 +364,7 @@ def yul(fork: Fork, request):
         assert solc_target_fork in get_forks_with_solc_support(request.config.solc_version)
     else:
         solc_target_fork = get_closest_fork_with_solc_support(fork, request.config.solc_version)
+        assert solc_target_fork is not None, "No fork supports provided solc version."
         if request.config.getoption("verbose") >= 1:
             warnings.warn(f"Compiling Yul for {solc_target_fork}, not {fork}.")
 


### PR DESCRIPTION
Removed the mapping stuff, `SOLC_VERSION_TO_SUPPORTED_FORKS` and `SOLC_FORKS_0_8_20`, in favor of a fork class method called `solc_min_version`.

Also modified `solc_name` to do a `.lower()` before returning, I think this should fix the issue where the name is incorrect but let me know if it doesn't accomplish what you needed :+1: 