### PR TITLE
forks(fix): Optional parameters on abstract fork class methods

### DIFF
--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -254,7 +254,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def solc_name(cls, block_number: int = 0, timestamp: int = 0) -> str:
+    def solc_name(cls) -> str:
         """
         Returns fork name as it's meant to be passed to the solc compiler.
         """
@@ -262,7 +262,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+    def solc_min_version(cls) -> Version:
         """
         Returns the minimum version of solc that supports this fork.
         """

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -24,7 +24,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         return cls.name()
 
     @classmethod
-    def solc_name(cls, block_number: int = 0, timestamp: int = 0) -> str:
+    def solc_name(cls) -> str:
         """
         Returns fork name as it's meant to be passed to the solc compiler.
         """
@@ -33,7 +33,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         return cls.name().lower()
 
     @classmethod
-    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+    def solc_min_version(cls) -> Version:
         """
         Returns the minimum version of solc that supports this fork.
         """
@@ -365,7 +365,7 @@ class Cancun(Shanghai):
         return False
 
     @classmethod
-    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+    def solc_min_version(cls) -> Version:
         """
         Returns the minimum version of solc that supports this fork.
         """

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -1,9 +1,10 @@
 """
 Base objects used to define transition forks.
 """
-from typing import List, Type
+from inspect import signature
+from typing import Callable, List, Type
 
-from .base_fork import BaseFork, Fork, ForkAttribute
+from .base_fork import BaseFork, Fork
 
 ALWAYS_TRANSITIONED_BLOCK_NUMBER = 10_000
 ALWAYS_TRANSITIONED_BLOCK_TIMESTAMP = 10_000_000
@@ -59,21 +60,29 @@ def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
         NewTransitionClass.name = lambda: transition_name  # type: ignore
 
         def make_transition_method(
-            base_method: ForkAttribute,
-            from_fork_method: ForkAttribute,
-            to_fork_method: ForkAttribute,
+            base_method: Callable,
+            from_fork_method: Callable,
+            to_fork_method: Callable,
         ):
+            base_method_parameters = signature(base_method).parameters
+
             def transition_method(
                 cls,
                 block_number: int = ALWAYS_TRANSITIONED_BLOCK_NUMBER,
                 timestamp: int = ALWAYS_TRANSITIONED_BLOCK_TIMESTAMP,
             ):
+                kwargs = {}
+                if "block_number" in base_method_parameters:
+                    kwargs["block_number"] = block_number
+                if "timestamp" in base_method_parameters:
+                    kwargs["timestamp"] = timestamp
+
                 if getattr(base_method, "__prefer_transition_to_method__", False):
-                    return to_fork_method(block_number=block_number, timestamp=timestamp)
+                    return to_fork_method(**kwargs)
                 return (
-                    to_fork_method(block_number=block_number, timestamp=timestamp)
+                    to_fork_method(**kwargs)
                     if block_number >= at_block and timestamp >= at_timestamp
-                    else from_fork_method(block_number=block_number, timestamp=timestamp)
+                    else from_fork_method(**kwargs)
                 )
 
             return classmethod(transition_method)


### PR DESCRIPTION
## 🗒️ Description
Makes parameters on fork class abstract methods optional by dynamically checking the function signature and only appending necessary parameters when creating the transition fork function.

@danceratopz @spencer-tb 